### PR TITLE
Support autoloading .salticidrc from $PWD as well as $HOME

### DIFF
--- a/bin/salticid
+++ b/bin/salticid
@@ -5,11 +5,15 @@ require 'trollop'
 require "#{File.dirname(__FILE__)}/../lib/salticid"
 require 'salticid/interface'
 
+rcfiles = [File.join(ENV["HOME"], '.salticidrc'), ".salticidrc"].select do |f|
+  File.exist? f
+end
+
 opts = Trollop::options do
   opt :exec, 'A command line to execute.', :type => :string
   opt :group, 'One or more groups to run task on', :type => :string, :multi => true
   opt :host, 'One or more hosts to run task on', :type => :string, :multi => true
-  opt :load, 'Files to load', :default => [File.join(ENV["HOME"], '.salticidrc')], :multi => true
+  opt :load, 'Files to load', :default => rcfiles, :multi => true
   opt :role, 'One or more roles. Every host in the role will have the specified task run.', :type => :string, :multi => true
   opt :show, 'Show roles, tasks, hosts, and groups. Try --show salticid or --show <host>', :type => :string
 end


### PR DESCRIPTION
This lets me have project or task specific configurations that don't overlap with each other.  The patch looks for both files and loads whatever exists.
