### PR TITLE
replaced deprecated Curses.endwin with Curses.close_screen

### DIFF
--- a/lib/salticid/interface.rb
+++ b/lib/salticid/interface.rb
@@ -163,7 +163,7 @@ class Salticid
       Curses.echo
       Curses.nocbreak
       Curses.nl
-      Curses.endwin
+      Curses.close_screen
 
       # Stop interface
       @main.exit rescue nil


### PR DESCRIPTION
`Curses.endwin` is no longer in the `Curses` module, and has been replaced by [`close_screen`](http://www.ruby-doc.org/stdlib-2.0/libdoc/curses/rdoc/Curses.html#method-c-close_screen).
